### PR TITLE
Fix Squarification & Cross-browser CSS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,12 @@ The `$area` of a node should be the sum of the `$area` of all of its
 attributes, `parent` and `dom`; this is only worth pointing out so
 that you don't accidentally conflict with them.)
 
+By default, appendTreemap will sort the tree's children from largest
+to smallest before placement. To retain the input order, pass an options
+argument to appendTreemap:
+
+        appendTreemap(document.getElementById('mynode'), mydata, {sort: false})
+
 ### CSS styling
 
 The treemap is constructed with one `div` per region with a separate

--- a/webtreemap.css
+++ b/webtreemap.css
@@ -6,10 +6,10 @@
   border: solid 1px black;  /* Calculations assume 1px border. */
 
   /* Optional: CSS animation. */
-  -webkit-transition: top    0.3s,
-                      left   0.3s,
-                      width  0.3s,
-                      height 0.3s;
+  transition: top    0.3s,
+              left   0.3s,
+              width  0.3s,
+              height 0.3s;
 }
 
 /* Optional: highlight nodes on mouseover. */

--- a/webtreemap.js
+++ b/webtreemap.js
@@ -154,15 +154,6 @@ function layout(tree, level, width, height) {
 
   var pixels_to_units = Math.sqrt(total / ((x2 - x1) * (y2 - y1)));
 
-  // The algorithm does best at laying out items from largest to smallest.
-  // Sort them to ensure this.
-  if (!tree.children.sorted) {
-    tree.children.sort(function (a, b) {
-      return b.data['$area'] - a.data['$area'];
-    });
-    tree.children.sorted = true;
-  }
-
   for (var start = 0, child; child = tree.children[start]; ++start) {
     if (x2 - x1 < 60 || y2 - y1 < 40) {
       if (child.dom) {
@@ -232,10 +223,27 @@ function layout(tree, level, width, height) {
   }
 }
 
-function appendTreemap(dom, data) {
+// The algorithm does best at laying out items from largest to smallest.
+// Recursively sort the tree to ensure this.
+function treeSort(tree) {
+  tree.children.sort(function (a, b) {
+    return b.data['$area'] - a.data['$area'];
+  });
+  for (var i = 0; i < tree.children.length; ++i) {
+    var child = tree.children[i];
+    if ('children' in child) {
+      treeSort(child);
+    }
+  }
+}
+
+function appendTreemap(dom, data, options) {
   var style = getComputedStyle(dom, null);
   var width = parseInt(style.width);
   var height = parseInt(style.height);
+  if (options === undefined || options.sort !== false) {
+    treeSort(data);
+  }
   if (!data.dom)
     makeDom(data, 0);
   dom.appendChild(data.dom);


### PR DESCRIPTION
The dynamic splitting fixes some pathological cases with large numbers of files that aren't so obvious in the Chrome bloat example.

See http://caniuse.com/#search=transition for information on prefix-less transition statements.